### PR TITLE
Added workaround for crash on iOS 12 betas

### DIFF
--- a/code/Kotoba.xcodeproj/project.pbxproj
+++ b/code/Kotoba.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		691B8E1620DAB5A100B11216 /* Workarounds.swift in Sources */ = {isa = PBXBuildFile; fileRef = 691B8E1520DAB5A100B11216 /* Workarounds.swift */; };
 		BE0CD1141D178D3700BB6E4A /* UIViewController+Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0CD1131D178D3700BB6E4A /* UIViewController+Dictionary.swift */; };
 		BE7599A11D04636E006FBB80 /* WordList.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE7599A01D04636E006FBB80 /* WordList.swift */; };
 		BE776E571D09D60700D4A315 /* Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE776E561D09D60700D4A315 /* Preferences.swift */; };
@@ -38,6 +39,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		691B8E1520DAB5A100B11216 /* Workarounds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workarounds.swift; sourceTree = "<group>"; };
 		BE0CD1131D178D3700BB6E4A /* UIViewController+Dictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+Dictionary.swift"; sourceTree = "<group>"; };
 		BE7599A01D04636E006FBB80 /* WordList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordList.swift; sourceTree = "<group>"; };
 		BE776E561D09D60700D4A315 /* Preferences.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Preferences.swift; sourceTree = "<group>"; };
@@ -111,6 +113,7 @@
 				BE0CD1131D178D3700BB6E4A /* UIViewController+Dictionary.swift */,
 				BE7599A01D04636E006FBB80 /* WordList.swift */,
 				BE776E561D09D60700D4A315 /* Preferences.swift */,
+				691B8E1520DAB5A100B11216 /* Workarounds.swift */,
 				BE918C531A22A5F5006043CF /* Main.storyboard */,
 				BE918C561A22A5F5006043CF /* Images.xcassets */,
 				BE918C4D1A22A5F5006043CF /* Supporting Files */,
@@ -297,6 +300,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				691B8E1620DAB5A100B11216 /* Workarounds.swift in Sources */,
 				BE7599A11D04636E006FBB80 /* WordList.swift in Sources */,
 				BE918C521A22A5F5006043CF /* WordListViewController.swift in Sources */,
 				BE820C601D14717400CD6ABA /* AddWordViewController.swift in Sources */,

--- a/code/Kotoba/Workarounds.swift
+++ b/code/Kotoba/Workarounds.swift
@@ -1,0 +1,24 @@
+//
+//  Workarounds.swift
+//  Kotoba
+//
+//  Created by Troy Gaul on 6/20/18.
+//  Copyright © 2018 Will Hains. All rights reserved.
+//
+
+import Foundation
+
+extension NSDictionary {
+	
+	// iOS 12 beta apparently has a crash (exception) where UIDictionaryManager tries to access
+	// a property via _isTTYEnabled that it expects to be a value (String or Number), probably
+	// from some dictionary somewhere, that it can turn into a Bool by calling boolValue, but on
+	// this OS version, the value it's getting back is a dictionary.  This workaround fixes that
+	// by implementing that method in an extension of NSDictionary to always return false.  This
+	// should be removed in the future if it's not needed because the underlying code is fixed.
+
+	@objc func boolValue() -> Bool {
+		return false
+	}
+	
+}


### PR DESCRIPTION
The workaround is to just implement a selector that was triggering the exception in a way that makes it not do so. It's not a long-term fix, but gets the app working again for now (tested on Beta 2 of iOS 12).