### PR TITLE
Modernization for iOS 13 plus a bit of branding.

### DIFF
--- a/code/Kotoba.xcodeproj/project.pbxproj
+++ b/code/Kotoba.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4440B41D236CF92100369CE8 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4440B41C236CF92100369CE8 /* Colors.xcassets */; };
 		691B8E1620DAB5A100B11216 /* Workarounds.swift in Sources */ = {isa = PBXBuildFile; fileRef = 691B8E1520DAB5A100B11216 /* Workarounds.swift */; };
 		B6F5588F21F20E8D0053F800 /* Launch.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B6F5588E21F20E8D0053F800 /* Launch.storyboard */; };
 		BE0CD1141D178D3700BB6E4A /* UIViewController+Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0CD1131D178D3700BB6E4A /* UIViewController+Dictionary.swift */; };
@@ -40,6 +41,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		4440B41C236CF92100369CE8 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		691B8E1520DAB5A100B11216 /* Workarounds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workarounds.swift; sourceTree = "<group>"; };
 		B6F5588E21F20E8D0053F800 /* Launch.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Launch.storyboard; sourceTree = "<group>"; };
 		BE0CD1131D178D3700BB6E4A /* UIViewController+Dictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+Dictionary.swift"; sourceTree = "<group>"; };
@@ -119,6 +121,7 @@
 				B6F5588E21F20E8D0053F800 /* Launch.storyboard */,
 				BE918C531A22A5F5006043CF /* Main.storyboard */,
 				BE918C561A22A5F5006043CF /* Images.xcassets */,
+				4440B41C236CF92100369CE8 /* Colors.xcassets */,
 				BE918C4D1A22A5F5006043CF /* Supporting Files */,
 			);
 			path = Kotoba;
@@ -221,7 +224,7 @@
 				TargetAttributes = {
 					BE918C491A22A5F5006043CF = {
 						CreatedOnToolsVersion = 6.2;
-						DevelopmentTeam = 8B38X92RJ6;
+						DevelopmentTeam = RYQWBTQRPT;
 						LastSwiftMigration = 1000;
 					};
 					BEA413B61D1CABB600D177C2 = {
@@ -241,6 +244,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -262,6 +266,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BE918C551A22A5F5006043CF /* Main.storyboard in Resources */,
+				4440B41D236CF92100369CE8 /* Colors.xcassets in Resources */,
 				BE918C571A22A5F5006043CF /* Images.xcassets in Resources */,
 				B6F5588F21F20E8D0053F800 /* Launch.storyboard in Resources */,
 			);
@@ -464,10 +469,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon-red";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = 8B38X92RJ6;
+				DEVELOPMENT_TEAM = RYQWBTQRPT;
 				INFOPLIST_FILE = Kotoba/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.willhains.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.iconfactory.Kotoba;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SWIFT_VERSION = 4.2;
@@ -481,10 +486,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon-red";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = 8B38X92RJ6;
+				DEVELOPMENT_TEAM = RYQWBTQRPT;
 				INFOPLIST_FILE = Kotoba/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.willhains.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.iconfactory.Kotoba;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";

--- a/code/Kotoba.xcodeproj/project.pbxproj
+++ b/code/Kotoba.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		4440B41D236CF92100369CE8 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4440B41C236CF92100369CE8 /* Colors.xcassets */; };
+		44CFA6AB2381F0CB00D7ECCC /* Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44CFA6AA2381F0CB00D7ECCC /* Debug.swift */; };
 		691B8E1620DAB5A100B11216 /* Workarounds.swift in Sources */ = {isa = PBXBuildFile; fileRef = 691B8E1520DAB5A100B11216 /* Workarounds.swift */; };
 		B6F5588F21F20E8D0053F800 /* Launch.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B6F5588E21F20E8D0053F800 /* Launch.storyboard */; };
 		BE0CD1141D178D3700BB6E4A /* UIViewController+Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0CD1131D178D3700BB6E4A /* UIViewController+Dictionary.swift */; };
@@ -42,6 +43,7 @@
 
 /* Begin PBXFileReference section */
 		4440B41C236CF92100369CE8 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
+		44CFA6AA2381F0CB00D7ECCC /* Debug.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Debug.swift; sourceTree = "<group>"; };
 		691B8E1520DAB5A100B11216 /* Workarounds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workarounds.swift; sourceTree = "<group>"; };
 		B6F5588E21F20E8D0053F800 /* Launch.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Launch.storyboard; sourceTree = "<group>"; };
 		BE0CD1131D178D3700BB6E4A /* UIViewController+Dictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+Dictionary.swift"; sourceTree = "<group>"; };
@@ -122,6 +124,7 @@
 				BE918C531A22A5F5006043CF /* Main.storyboard */,
 				BE918C561A22A5F5006043CF /* Images.xcassets */,
 				4440B41C236CF92100369CE8 /* Colors.xcassets */,
+				44CFA6AA2381F0CB00D7ECCC /* Debug.swift */,
 				BE918C4D1A22A5F5006043CF /* Supporting Files */,
 			);
 			path = Kotoba;
@@ -314,6 +317,7 @@
 				BE918C521A22A5F5006043CF /* WordListViewController.swift in Sources */,
 				BE820C601D14717400CD6ABA /* AddWordViewController.swift in Sources */,
 				BE776E571D09D60700D4A315 /* Preferences.swift in Sources */,
+				44CFA6AB2381F0CB00D7ECCC /* Debug.swift in Sources */,
 				BE0CD1141D178D3700BB6E4A /* UIViewController+Dictionary.swift in Sources */,
 				BE918C501A22A5F5006043CF /* AppDelegate.swift in Sources */,
 			);
@@ -475,6 +479,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.iconfactory.Kotoba;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/code/Kotoba/AddWordViewController.swift
+++ b/code/Kotoba/AddWordViewController.swift
@@ -23,7 +23,7 @@ final class AddWordViewController: UIViewController
 		super.viewDidLoad()
 		prepareKeyboardAvoidance()
 		
-		let titleFont = UIFont.systemFont(ofSize: 22.0, weight: .bold)
+		let titleFont = UIFont.init(name: "AmericanTypewriter-Semibold", size: 22) ?? UIFont.systemFont(ofSize: 22.0, weight: .bold)
 		let titleColor = UIColor.init(named: "appHeader") ?? UIColor.label
 		self.navigationController?.navigationBar.titleTextAttributes = [ .font: titleFont, .foregroundColor: titleColor ]
 	}

--- a/code/Kotoba/AddWordViewController.swift
+++ b/code/Kotoba/AddWordViewController.swift
@@ -23,7 +23,7 @@ final class AddWordViewController: UIViewController
 		super.viewDidLoad()
 		prepareKeyboardAvoidance()
 		
-		let titleFont = UIFont.init(name: "AmericanTypewriter-Semibold", size: 22) ?? UIFont.systemFont(ofSize: 22.0, weight: .bold)
+		let titleFont = UIFont.init(name: "AmericanTypewriter-Bold", size: 22) ?? UIFont.systemFont(ofSize: 22.0, weight: .bold)
 		let titleColor = UIColor.init(named: "appHeader") ?? UIColor.label
 		self.navigationController?.navigationBar.titleTextAttributes = [ .font: titleFont, .foregroundColor: titleColor ]
 		

--- a/code/Kotoba/AddWordViewController.swift
+++ b/code/Kotoba/AddWordViewController.swift
@@ -23,7 +23,9 @@ final class AddWordViewController: UIViewController
 		super.viewDidLoad()
 		prepareKeyboardAvoidance()
 		
-		self.navigationController?.navigationBar.titleTextAttributes = [ .font: UIFont.systemFont(ofSize: 22.0, weight: .bold) ]
+		let titleFont = UIFont.systemFont(ofSize: 22.0, weight: .bold)
+		let titleColor = UIColor.init(named: "appHeader") ?? UIColor.label
+		self.navigationController?.navigationBar.titleTextAttributes = [ .font: titleFont, .foregroundColor: titleColor ]
 	}
 	
 	override func viewWillAppear(_ animated: Bool) {

--- a/code/Kotoba/AppDelegate.swift
+++ b/code/Kotoba/AppDelegate.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 // Theme colour for app icon and tint
-let redThemeColour = UIColor(hue: 5.0, saturation: 0.73, brightness: 0.65, alpha: 1.0)
+let redThemeColour = UIColor(named: "appTint") ?? UIColor(hue: 5.0, saturation: 0.73, brightness: 0.65, alpha: 1.0)
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate

--- a/code/Kotoba/Base.lproj/Main.storyboard
+++ b/code/Kotoba/Base.lproj/Main.storyboard
@@ -1,12 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="uqs-b9-3Ik">
-    <device id="retina4_0" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="uqs-b9-3Ik">
+    <device id="retina4_0" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Alignment constraints to the first baseline" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -18,20 +14,19 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="kNU-bZ-hng">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="Word" textLabel="Eh3-mK-Sxg" style="IBUITableViewCellStyleDefault" id="zq0-Qe-pPh">
                                 <rect key="frame" x="0.0" y="28" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="zq0-Qe-pPh" id="RwW-O5-MoZ">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Eh3-mK-Sxg">
-                                            <rect key="frame" x="16" y="0.0" width="288" height="43.5"/>
+                                            <rect key="frame" x="16" y="0.0" width="288" height="44"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
@@ -58,7 +53,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" placeholder="Type a Word" textAlignment="center" adjustsFontSizeToFit="NO" minimumFontSize="42" translatesAutoresizingMaskIntoConstraints="NO" id="NcX-Q6-lwW" userLabel="Text Field">
-                                <rect key="frame" x="20" y="275.5" width="280" height="51"/>
+                                <rect key="frame" x="20" y="265.5" width="280" height="51"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="42"/>
                                 <textInputTraits key="textInputTraits" returnKeyType="search" enablesReturnKeyAutomatically="YES"/>
                                 <connections>
@@ -66,7 +61,7 @@
                                 </connections>
                             </textField>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
                             <constraint firstItem="NcX-Q6-lwW" firstAttribute="centerX" secondItem="W0c-l2-07F" secondAttribute="centerX" id="0yv-gt-YIW"/>
                             <constraint firstItem="NcX-Q6-lwW" firstAttribute="width" secondItem="4xg-Iq-PCO" secondAttribute="width" constant="-40" id="KFr-Iw-7TC"/>
@@ -95,7 +90,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="uqs-b9-3Ik" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="I2T-4W-xZ2">
-                        <rect key="frame" x="0.0" y="20" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/code/Kotoba/Base.lproj/Main.storyboard
+++ b/code/Kotoba/Base.lproj/Main.storyboard
@@ -52,9 +52,12 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" placeholder="Type a Word" textAlignment="center" adjustsFontSizeToFit="NO" minimumFontSize="42" translatesAutoresizingMaskIntoConstraints="NO" id="NcX-Q6-lwW" userLabel="Text Field">
-                                <rect key="frame" x="20" y="265.5" width="280" height="51"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="42"/>
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" placeholder="Type a Word" textAlignment="center" minimumFontSize="12" translatesAutoresizingMaskIntoConstraints="NO" id="NcX-Q6-lwW" userLabel="Text Field">
+                                <rect key="frame" x="10" y="267.5" width="300" height="49"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="300" id="3xP-rx-8MB"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" name="AmericanTypewriter" family="American Typewriter" pointSize="42"/>
                                 <textInputTraits key="textInputTraits" returnKeyType="search" enablesReturnKeyAutomatically="YES"/>
                                 <connections>
                                     <outlet property="delegate" destination="JNO-hA-UHa" id="gMV-3x-7t1"/>
@@ -64,7 +67,6 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
                             <constraint firstItem="NcX-Q6-lwW" firstAttribute="centerX" secondItem="W0c-l2-07F" secondAttribute="centerX" id="0yv-gt-YIW"/>
-                            <constraint firstItem="NcX-Q6-lwW" firstAttribute="width" secondItem="4xg-Iq-PCO" secondAttribute="width" constant="-40" id="KFr-Iw-7TC"/>
                             <constraint firstItem="NcX-Q6-lwW" firstAttribute="firstBaseline" secondItem="W0c-l2-07F" secondAttribute="centerY" id="xRg-NG-Nmb"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="W0c-l2-07F"/>

--- a/code/Kotoba/Base.lproj/Main.storyboard
+++ b/code/Kotoba/Base.lproj/Main.storyboard
@@ -69,7 +69,8 @@
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="W0c-l2-07F"/>
                     </view>
-                    <navigationItem key="navigationItem" title="Word Lookup" id="YQw-TU-c8o">
+                    <navigationItem key="navigationItem" title="Kotoba" id="YQw-TU-c8o">
+                        <barButtonItem key="backBarButtonItem" title=" " id="12J-us-Q9r"/>
                         <barButtonItem key="rightBarButtonItem" title="History" id="lxn-9Q-keE">
                             <connections>
                                 <segue destination="PII-AL-jNA" kind="show" id="KTZ-QU-EDq"/>

--- a/code/Kotoba/Colors.xcassets/Contents.json
+++ b/code/Kotoba/Colors.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/code/Kotoba/Colors.xcassets/appHeader.colorset/Contents.json
+++ b/code/Kotoba/Colors.xcassets/appHeader.colorset/Contents.json
@@ -27,10 +27,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0.907",
+          "red" : "1.000",
           "alpha" : "1.000",
-          "blue" : "0.245",
-          "green" : "0.317"
+          "blue" : "0.585",
+          "green" : "0.630"
         }
       }
     }

--- a/code/Kotoba/Colors.xcassets/appHeader.colorset/Contents.json
+++ b/code/Kotoba/Colors.xcassets/appHeader.colorset/Contents.json
@@ -9,10 +9,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0.651",
+          "red" : "0.400",
           "alpha" : "1.000",
-          "blue" : "0.176",
-          "green" : "0.216"
+          "blue" : "0.078",
+          "green" : "0.114"
         }
       }
     },
@@ -27,10 +27,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "255",
+          "red" : "0.907",
           "alpha" : "1.000",
-          "blue" : "69",
-          "green" : "84"
+          "blue" : "0.245",
+          "green" : "0.317"
         }
       }
     }

--- a/code/Kotoba/Colors.xcassets/appTint.colorset/Contents.json
+++ b/code/Kotoba/Colors.xcassets/appTint.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.651",
+          "alpha" : "1.000",
+          "blue" : "0.176",
+          "green" : "0.216"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "218",
+          "alpha" : "1.000",
+          "blue" : "59",
+          "green" : "72"
+        }
+      }
+    }
+  ]
+}

--- a/code/Kotoba/Debug.swift
+++ b/code/Kotoba/Debug.swift
@@ -1,0 +1,33 @@
+//
+//  Debug.swift
+//  Linea
+//
+//  Created by Craig Hockenberry on 10/4/19.
+//
+//  Usage:
+//    debugLog("reticulating splines")  prints "2019-10-04 11:52:28 SplineReticulationManager: reticulationFunction reticulating splines"
+//    debugLog()                        prints "2019-10-04 11:52:28 SplineReticulationManager: reticulationFunction called"
+
+import Foundation
+
+func releaseLog(_ message: String = "called", file: String = #file, function: String = #function) {
+	let timestamp = ISO8601DateFormatter.string(from: Date(), timeZone: TimeZone.current, formatOptions: [.withYear, .withMonth, .withDay, .withDashSeparatorInDate, .withTime, .withColonSeparatorInTime, .withSpaceBetweenDateAndTime])
+	print("\(timestamp) \(URL(fileURLWithPath: file).deletingPathExtension().lastPathComponent): \(function) \(message)")
+}
+
+func debugLog(_ message: String = "called", file: String = #file, function: String = #function) {
+	#if DEBUG
+		let timestamp = ISO8601DateFormatter.string(from: Date(), timeZone: TimeZone.current, formatOptions: [.withYear, .withMonth, .withDay, .withDashSeparatorInDate, .withTime, .withColonSeparatorInTime, .withSpaceBetweenDateAndTime])
+		print("\(timestamp) \(URL(fileURLWithPath: file).deletingPathExtension().lastPathComponent): \(function) \(message)")
+	#endif
+}
+
+#if true
+	
+// weed out NSLog usage
+@available(iOS, deprecated: 1.0, message: "Convert to debugLog")
+public func NSLog(_ format: String, _ args: CVarArg...)
+{
+}
+	
+#endif

--- a/code/Kotoba/Info.plist
+++ b/code/Kotoba/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>475</string>
+	<string>517</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/code/Kotoba/Info.plist
+++ b/code/Kotoba/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>552</string>
+	<string>557</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/code/Kotoba/Info.plist
+++ b/code/Kotoba/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>524</string>
+	<string>536</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/code/Kotoba/Info.plist
+++ b/code/Kotoba/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>517</string>
+	<string>524</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/code/Kotoba/Info.plist
+++ b/code/Kotoba/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>536</string>
+	<string>552</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/code/Kotoba/UIViewController+Dictionary.swift
+++ b/code/Kotoba/UIViewController+Dictionary.swift
@@ -13,15 +13,13 @@ extension UIViewController
 {
 	/// Present the system dictionary as a modal view, showing the definition of `word`.
 	/// - returns: `true` if the system dictionary found a definition, `false` otherwise.
-	func showDefinition(forWord word: Word) -> Bool
+	func showDefinition(forWord word: Word, completion: (() -> Void)? = nil)
 	{
 		let dictionaryViewController = UIReferenceLibraryViewController(term: word.text)
-		present(dictionaryViewController, animated: true, completion: nil)
-//		navigationController?.pushViewController(dictionaryViewController, animated: true)
+		self.present(dictionaryViewController, animated: true, completion: completion)
 		
 		// Prompt the user to set up their iOS dictionaries, the first time they use this only
-		if prefs.shouldDisplayFirstUseDictionaryPrompt()
-		{
+		if prefs.shouldDisplayFirstUseDictionaryPrompt() {
 			let alert = UIAlertController(
 				title: "Add Dictionaries",
 				message: """
@@ -35,9 +33,5 @@ extension UIViewController
 			// Update preferences to silence this prompt next time
 			prefs.didDisplayFirstUseDictionaryPrompt()
 		}
-		
-		// Return whether definition for word was found
-		//return UIReferenceLibraryViewController.dictionaryHasDefinition(forTerm: word.text)
-		return true
 	}
 }

--- a/code/Kotoba/UIViewController+Dictionary.swift
+++ b/code/Kotoba/UIViewController+Dictionary.swift
@@ -17,6 +17,7 @@ extension UIViewController
 	{
 		let dictionaryViewController = UIReferenceLibraryViewController(term: word.text)
 		present(dictionaryViewController, animated: true, completion: nil)
+//		navigationController?.pushViewController(dictionaryViewController, animated: true)
 		
 		// Prompt the user to set up their iOS dictionaries, the first time they use this only
 		if prefs.shouldDisplayFirstUseDictionaryPrompt()
@@ -36,6 +37,7 @@ extension UIViewController
 		}
 		
 		// Return whether definition for word was found
-		return UIReferenceLibraryViewController.dictionaryHasDefinition(forTerm: word.text)
+		//return UIReferenceLibraryViewController.dictionaryHasDefinition(forTerm: word.text)
+		return true
 	}
 }

--- a/code/Kotoba/WordListViewController.swift
+++ b/code/Kotoba/WordListViewController.swift
@@ -67,7 +67,7 @@ extension WordListViewController
 	{
 		// Search the dictionary
 		let word = words[indexPath.row]
-		let _ = showDefinition(forWord: word)
+		showDefinition(forWord: word)
 		
 		// Reset the table view
 		self.tableView.deselectRow(at: indexPath, animated: true)


### PR DESCRIPTION
This pull request contains quite a few things:

* Support for Dark Mode in iOS 13
* A workaround for the UIReferenceLibraryViewController slowness in iOS 13 (see comment in `initiateSearch()` of `AddWordViewController`)
* Some subtle new branding for the app (using color and the American Typewriter font)
* A check for text on the clipboard when the app becomes frontmost
* A partial fix for a janky animation from WordListViewController to AddWordViewController

Feel free to cherry pick whatever you want.