### PR TITLE
79: Move `canonicalise` logic to `init`, and trim quotes.

### DIFF
--- a/code/Kotoba/Word.swift
+++ b/code/Kotoba/Word.swift
@@ -13,12 +13,17 @@ import UIKit
 /// Represents a saved word.
 struct Word
 {
+	private static let QUOTES = CharacterSet(charactersIn: "\"'“”‘’")
+
 	let text: String
 
-	// TODO #14: This is where metadata would go.
-
-	func canonicalise() -> String
+	init(text: String)
 	{
-		self.text.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+		self.text = text
+			.lowercased()
+			.trimmingCharacters(in: .whitespacesAndNewlines)
+			.trimmingCharacters(in: Word.QUOTES)
 	}
+
+	// TODO #14: This is where metadata would go.
 }

--- a/code/Kotoba/WordListDataSource.swift
+++ b/code/Kotoba/WordListDataSource.swift
@@ -44,7 +44,7 @@ extension WordListDataSource where Self: WordListStrings
 	mutating func add(word: Word)
 	{
 		// Prevent duplicates; move to top of list instead
-		wordStrings.add(possibleDuplicate: word.canonicalise())
+		wordStrings.add(possibleDuplicate: word.text)
 		debugLog("add: wordStrings=\(wordStrings.first ?? "")..\(wordStrings.last ?? "")")
 	}
 


### PR DESCRIPTION
Fixes #79 