### PR TITLE
Cleanup alternate mode logic and enablement

### DIFF
--- a/code/Kotoba/AddWord/AddWordView.swift
+++ b/code/Kotoba/AddWord/AddWordView.swift
@@ -6,20 +6,6 @@ import UIKit
 /// of suggested words pulled from the pasteboard.
 struct AddWordView: View
 {
-	/// Alerts that are allowed to be displayed by this view.
-	enum Alert: Identifiable
-	{
-		case chocktuba(enabled: Bool)
-
-		var id: String
-		{
-			switch self
-			{
-				case .chocktuba(let enabled): "chocktuba:\(enabled)"
-			}
-		}
-	}
-
 	/// Sheets that are allowed to be displayed by this view.
 	enum Sheet: Identifiable
 	{
@@ -45,8 +31,6 @@ struct AddWordView: View
 	@State private var typedWord: String = ""
 	@State private var wordSuggestionsModel: WordSuggestionsModel
 
-	@Environment(\.chocktubaEnabled) var chocktubaEnabled
-
 	init(wordSuggestionsModel: WordSuggestionsModel)
 	{
 		self.wordSuggestionsModel = wordSuggestionsModel
@@ -60,21 +44,15 @@ struct AddWordView: View
 			{
 				Spacer()
 
-				TextField("ADD_WORD_LOOKUP_PLACEHOLDER", text: $typedWord)
-					.minimumScaleFactor(0.5)
-					.textInputAutocapitalization(chocktubaEnabled ? .characters : .never)
-					.focused($isTextFieldFocused)
-					.onSubmit
+				AddWordTextField(
+					"ADD_WORD_LOOKUP_PLACEHOLDER",
+					text: $typedWord,
+					onSubmit:
 					{
-						if typedWord.trimmingCharacters(in: .whitespacesAndNewlines) == Chocktuba.activationPhrase
-						{
-							toggleChocktuba()
-						}
-						else
-						{
-							lookupWord(term: Word(text: typedWord))
-						}
-					}
+						lookupWord(term: Word(text: typedWord))
+					})
+					.minimumScaleFactor(0.5)
+					.focused($isTextFieldFocused)
 					.font(.custom("AmericanTypewriter", size: 42))
 					.multilineTextAlignment(.center)
 					.padding()
@@ -169,41 +147,6 @@ struct AddWordView: View
 					WordListView()
 			}
 		}
-		.alert(
-			item: $alert,
-			title:
-			{
-				item in
-				switch item
-				{
-					case .chocktuba(let enabled):
-						Text("CHOCKTUBA \(enabled ? "ON" : "OFF")")
-				}
-			},
-			actions:
-			{
-				item in
-				Button("CTL ALT DEL TO RESTART")
-				{
-					exit(0)
-				}
-			},
-			message:
-			{
-				item in
-				switch item
-				{
-					case .chocktuba(let enabled):
-						if enabled
-						{
-							Text("YOU JUST MADE THIS APP A BILLION TIMES BETTER CONGRATS")
-						}
-						else
-						{
-							Text("WHAT THE HELL ARE YOU THINKING")
-						}
-				}
-			})
 		.tint(Color("appTint"))
 	}
 
@@ -222,12 +165,6 @@ struct AddWordView: View
 		isSearching = true
 
 		sheet = .dictionary(term: term)
-	}
-
-	private func toggleChocktuba()
-	{
-		alert = .chocktuba(enabled: !Chocktuba.isEnabled)
-		Chocktuba.toggle()
 	}
 }
 

--- a/code/Kotoba/AddWord/WordSuggestionsView.swift
+++ b/code/Kotoba/AddWord/WordSuggestionsView.swift
@@ -11,8 +11,6 @@ struct WordSuggestionsView: View
 	/// be used to constrain the height of the list if the contents are sufficiently small.
 	@State var contentHeight: CGFloat = 0.0
 
-	@Environment(\.chocktubaEnabled) var chocktubaEnabled
-
 	init(
 		model: WordSuggestionsModel,
 		onTapSuggestion: @escaping (Word) -> Void)
@@ -61,7 +59,7 @@ struct WordSuggestionsView: View
 							onTapSuggestion(suggestion)
 						})
 						{
-							Text(chocktubaEnabled ? suggestion.text.uppercased() : suggestion.text)
+							Text(suggestion.text)
 						}
 					}
 				}

--- a/code/Kotoba/Chocktuba.swift
+++ b/code/Kotoba/Chocktuba.swift
@@ -3,6 +3,7 @@
 // Copyright (c) 2020 Will Hains. All rights reserved.
 //
 
+import Foundation
 import SwiftUI
 import UIKit
 
@@ -71,6 +72,87 @@ extension EnvironmentValues
 	{
 		get { self[ChocktubaKey.self] }
 		set { self[ChocktubaKey.self] = newValue }
+	}
+}
+
+// MARK:- Root
+
+struct ChocktubaModifier: ViewModifier
+{
+	@Environment(\.chocktubaEnabled) var chocktubaEnabled
+
+	func body(content: Content) -> some View
+	{
+		content.textCase(chocktubaEnabled ? .uppercase : nil)
+	}
+}
+
+extension View
+{
+	var kotobaView: some View
+	{
+		self.modifier(ChocktubaModifier())
+	}
+}
+
+// MARK:- AddWordView
+
+struct AddWordTextField: View
+{
+	let titleKey: LocalizedStringKey
+	let text: Binding<String>
+	let onSubmit: () -> Void
+	@State var showingAlert = false
+
+	@Environment(\.chocktubaEnabled) var chocktubaEnabled
+
+	init(_ titleKey: LocalizedStringKey, text: Binding<String>, onSubmit: @escaping () -> Void)
+	{
+		self.titleKey = titleKey
+		self.text = text
+		self.onSubmit = onSubmit
+	}
+
+	var body: some View
+	{
+		TextField(titleKey, text: text)
+			.textInputAutocapitalization(chocktubaEnabled ? .characters : .never)
+			.onSubmit
+			{
+				if text.wrappedValue.trimmingCharacters(in: .whitespacesAndNewlines) == Chocktuba.activationPhrase
+				{
+					Chocktuba.toggle()
+					Task
+					{
+						showingAlert = true
+					}
+				}
+				else
+				{
+					onSubmit()
+				}
+			}
+			.alert(
+				Text("CHOCKTUBA \(!chocktubaEnabled ? "ON" : "OFF")"),
+				isPresented: $showingAlert,
+				actions:
+				{
+					Button("CTL ALT DEL TO RESTART")
+					{
+						exit(0)
+					}
+				},
+				message:
+				{
+					if !chocktubaEnabled
+					{
+						Text("YOU JUST MADE THIS APP A BILLION TIMES BETTER CONGRATS")
+					}
+					else
+					{
+						Text("WHAT THE HELL ARE YOU THINKING")
+					}
+				})
 	}
 }
 

--- a/code/Kotoba/SceneDelegate.swift
+++ b/code/Kotoba/SceneDelegate.swift
@@ -20,7 +20,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate
 				pasteboard: RealPasteboard(pasteboard: UIPasteboard.general),
 				userDefaults: .standard))
 
-		window?.rootViewController = UIHostingController(rootView: rootView)
+		window?.rootViewController = UIHostingController(rootView: rootView.kotobaView)
 		window?.makeKeyAndVisible()
 	}
 }


### PR DESCRIPTION
Thank you for the updates to my last pull request! The styling of this one should better match the current repo. Apologies for missing this in my previous one.

I wasn't happy with how the last PR sprinkled secret mode code in with the new SwiftUI code. After thinking about it for a bit, I thought that this might be a good place to use a SwiftUI ViewModifier to clean things up, as well as a custom TextField to wrap the toggling logic.

### Changes

* Define a new `AddWordTextField` that wraps a standard `TextField` but includes the alternate mode toggling logic.
* Use a SwiftUI `ViewModifier` to automatically uppercase words.